### PR TITLE
Improve flow types

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -3,22 +3,24 @@
 opaque type Next = Function | void;
 opaque type Yield = mixed;
 
-export type Gensync<T> = {
-  (...args: Array<mixed>): Handler<T>,
-  sync(...args: Array<mixed>): T,
-  async(...args: Array<mixed>): Promise<T>,
-  errback(...args: Array<mixed>): void,
+export type Gensync<Args, Return> = {
+  (...args: Args): Handler<Args, Return>,
+  sync(...args: Args): Return,
+  async(...args: Args): Promise<Return>,
+  // ...args: [...Args, Callback]
+  errback(...args: any[]): void,
 };
 
-export type Handler<T> = Generator<Yield, T, Next>;
-export type Options<T> = {
-  sync: (...args: Array<mixed>) => T,
-  async: (...args: Array<mixed>) => Promise<T>,
-  errback: (...args: Array<mixed>) => void,
+export type Handler<Args, Return> = (...args: Args) => Generator<Yield, Return, Next>;
+export type Options<Args, Return> = {
+  sync: (...args: Args) => Return,
+  async: (...args: Args) => Promise<Return>,
+  // ...args: [...Args, Callback]
+  errback: (...args: any[]) => void,
   arity?: number,
   name?: string,
 };
 
 declare module.exports: {
-  <T>(Options<T> | Handler<T>): Gensync<T>,
+  <Args, Return>(Options<Return> | Handler<Args, Return>): Gensync<Args, Return>,
 };

--- a/index.js.flow
+++ b/index.js.flow
@@ -17,7 +17,7 @@ export type Options<Args, Return> = {
   arity?: number,
   name?: string,
 } & (
-  | { async(...args: Args): Promise<Return> }
+  | { async?: (...args: Args) => Promise<Return> }
   // ...args: [...Args, Callback]
   | { errback(...args: any[]): void }
 );

--- a/index.js.flow
+++ b/index.js.flow
@@ -4,14 +4,14 @@ opaque type Next = Function | void;
 opaque type Yield = mixed;
 
 export type Gensync<Args, Return> = {
-  (...args: Args): Handler<Args, Return>,
+  (...args: Args): Handler<Return>,
   sync(...args: Args): Return,
   async(...args: Args): Promise<Return>,
   // ...args: [...Args, Callback]
   errback(...args: any[]): void,
 };
 
-export type Handler<Args, Return> = (...args: Args) => Generator<Yield, Return, Next>;
+export type Handler<Return> = Generator<Yield, Return, Next>;
 export type Options<Args, Return> = {
   sync: (...args: Args) => Return,
   async: (...args: Args) => Promise<Return>,
@@ -22,5 +22,5 @@ export type Options<Args, Return> = {
 };
 
 declare module.exports: {
-  <Args, Return>(Options<Return> | Handler<Args, Return>): Gensync<Args, Return>,
+  <Args, Return>(Options<Args, Return> | (...args: Args) => Handler<Return>): Gensync<Args, Return>,
 };

--- a/index.js.flow
+++ b/index.js.flow
@@ -13,14 +13,17 @@ export type Gensync<Args, Return> = {
 
 export type Handler<Return> = Generator<Yield, Return, Next>;
 export type Options<Args, Return> = {
-  sync: (...args: Args) => Return,
-  async: (...args: Args) => Promise<Return>,
-  // ...args: [...Args, Callback]
-  errback: (...args: any[]) => void,
+  sync(...args: Args): Return,
   arity?: number,
   name?: string,
-};
+} & (
+  | { async(...args: Args): Promise<Return> }
+  // ...args: [...Args, Callback]
+  | { errback(...args: any[]): void }
+);
 
 declare module.exports: {
-  <Args, Return>(Options<Args, Return> | (...args: Args) => Handler<Return>): Gensync<Args, Return>,
+  <Args, Return>(
+    Options<Args, Return> | ((...args: Args) => Handler<Return>)
+  ): Gensync<Args, Return>,
 };

--- a/index.js.flow
+++ b/index.js.flow
@@ -26,4 +26,7 @@ declare module.exports: {
   <Args, Return>(
     Options<Args, Return> | ((...args: Args) => Handler<Return>)
   ): Gensync<Args, Return>,
+
+  all<Return>(Array<Handler<Return>>): Handler<Return[]>,
+  race<Return>(Array<Handler<Return>>): Handler<Return>,
 };


### PR DESCRIPTION
1. `Generator<...>` is the return type of a generator function, not the generator itself
2. Add an `Args` type parameter, so that it's possible to specify arguments type in a way
   that works both inside and outside the `gensync` call:

   ```js
   var fn = gensync<[number, number], string>(function* (x, y) { return "" });
   ```

I had to use `any` because with `mixed` I got errors about it not being compatible with the types of the generator function.