### PR TITLE
Don't publish tests in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+test
 .eslintrc
 .flowconfig
 .gitignore


### PR DESCRIPTION
There is no reason to publish tests into the package. Caught me accidentally when I run `mocha **/*.test.js`, not expecting to include tests from `node_modules`