### PR TITLE
fix #26, modernize pkg config

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@
 .prettierrc
 .travis.yml
 yarn.lock
+test/

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "description": "Allows users to use generators in order to write common functions that can be both sync or async.",
   "main": "index.js",
+  "files": ["index.js"],
   "author": "Logan Smyth <loganfsmyth@gmail.com>",
   "homepage": "https://github.com/loganfsmyth/gensync",
   "repository": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const promisify = require("util.promisify");
+const promisify = require("util").promisify;
 const gensync = require("../");
 
 const TEST_ERROR = new Error("TEST_ERROR");


### PR DESCRIPTION
This PR provides:
1. Fix to a modern use of `require()`, which doesn't fail on `node@>=10.24`.
2. I noticed from the flowconfig that it only defines index.js as the single file of code needed for the module.  This same construct is available via files directive in `package.json`.
3. The previous alternative to the files directive is the definition of `.npmignore`.  I updated this to solve the issue in case `files` directive is not desired.  The do not conflict with each other and `files` array takes precedence.

Resolves #26 